### PR TITLE
Fix issue where nested json objects are serialized incorrectly

### DIFF
--- a/src/Umbraco.CourierProviders.Core/NestedContent/NestedContentDataResolverProvider.cs
+++ b/src/Umbraco.CourierProviders.Core/NestedContent/NestedContentDataResolverProvider.cs
@@ -143,8 +143,16 @@
                                 string serializedValue = firstDataType.Value as string ??
                                                          JsonConvert.SerializeObject(firstDataType.Value);
 
-
-                                ncObj[propertyType.Alias] = new JValue(serializedValue);
+                                try
+                                {
+                                    // attempt to parse in case of valid json object
+                                    ncObj[propertyType.Alias] = JToken.Parse(serializedValue);
+                                }
+                                catch(JsonReaderException ex)
+                                {
+                                    // revert to JValue
+                                    ncObj[propertyType.Alias] = new JValue(serializedValue);
+                                }
 
                                 // (if packaging) add a dependency for the property's data-type
                                 if (direction == Direction.Packaging)


### PR DESCRIPTION
Hi,

We were running across an issue where a DTGE component contained a NC which in-turn contained a RJP.MultiPicker (Don't ask!)

The symptom was that the angular controller for the multipicker was going haywire and rendering numerous empty links. The cause was that the multipickers's JSON data was being serialised as a string rather than a json object (essentially wrapped in double quotes)

This PR attempts to recognise JSON objects or arrays before catching the specific newton soft exception and reverting to the old behaviour. We've tested this on many courier operations since.